### PR TITLE
Update deprecated pandas offset alias

### DIFF
--- a/docs/user-guide/4-peaks-over-threshold.md
+++ b/docs/user-guide/4-peaks-over-threshold.md
@@ -36,14 +36,14 @@ parameters of the `get_extremes` function:
     from pyextremes import get_extremes
     from pyextremes.plotting import plot_extremes
 
-    extremes = get_extremes(data, "POT", threshold=0.5, r="12H")
+    extremes = get_extremes(data, "POT", threshold=0.5, r="12h")
     plot_extremes(
         ts=data,
         extremes=extremes,
         extremes_method="POT",
         extremes_type="high",
         threshold=0.5,
-        r="12H",
+        r="12h",
     )
     ```
 
@@ -53,7 +53,7 @@ parameters of the `get_extremes` function:
     from pyextremes import EVA
 
     model = EVA(data=data)
-    model.get_extremes("POT", threshold=0.5, r="12H")
+    model.get_extremes("POT", threshold=0.5, r="12h")
     model.plot_extremes(show_clusters=True)
     ```
 
@@ -104,7 +104,7 @@ The following paramters are used only when `#!python method="POT"`:
   to decluster exceedances by locating clusters where all exceedances are separated
   by distances no more than `r` and then locating maximum or minimum
   (depends on `extremes_type`) values within each cluster.
-  By default `#!python r="24H"` (24 hours).
+  By default `#!python r="24h"` (24 hours).
 
 If we specify all of these parameters then the function would look as:
 
@@ -114,7 +114,7 @@ get_extremes(
     method="POT",
     extremes_type="high",
     threshold=0.5,
-    r="12H",
+    r="12h",
 )
 ```
 
@@ -129,14 +129,14 @@ extracted from the same data and using the same threshold as above, but with a l
 === "Standalone"
 
     ```python
-    extremes = get_extremes(data, "POT", threshold=0.5, r="24H")
+    extremes = get_extremes(data, "POT", threshold=0.5, r="24h")
     plot_extremes(
         ts=data,
         extremes=extremes,
         extremes_method="POT",
         extremes_type="high",
         threshold=0.5,
-        r="24H",
+        r="24h",
     )
     ```
 
@@ -144,7 +144,7 @@ extracted from the same data and using the same threshold as above, but with a l
 
     ```python
     model = EVA(data=data)
-    model.get_extremes("POT", threshold=0.5, r="24H")
+    model.get_extremes("POT", threshold=0.5, r="24h")
     model.plot_extremes(show_clusters=True)
     ```
 
@@ -153,7 +153,7 @@ extracted from the same data and using the same threshold as above, but with a l
 </figure>
 
 !!! tip
-    Declustering value of `#!python r="24H"` was selected as a default value because
+    Declustering value of `#!python r="24h"` was selected as a default value because
     `pyextremes` was developed when working with meteorological phenomena - namely,
     storms. Extreme storm surge and waves are generally caused by a storm event which
     generally doesn't exceed 12-24 hours and, because of this, the assumption of 24-hour
@@ -178,7 +178,7 @@ by setting the `extremes_type` argument to `#!python "low"`:
         data,
         "POT",
         threshold=0.5,
-        r="24H",
+        r="24h",
         extremes_type="low",
     )
     plot_extremes(
@@ -187,7 +187,7 @@ by setting the `extremes_type` argument to `#!python "low"`:
         extremes_method="POT",
         extremes_type="low",
         threshold=0.5,
-        r="24H",
+        r="24h",
     )
     ```
 
@@ -195,7 +195,7 @@ by setting the `extremes_type` argument to `#!python "low"`:
 
     ```python
     model = EVA(data=data)
-    model.get_extremes("POT", threshold=0.5, r="24H", extremes_type="low")
+    model.get_extremes("POT", threshold=0.5, r="24h", extremes_type="low")
     model.plot_extremes(show_clusters=True)
     ```
 

--- a/docs/user-guide/5-threshold-selection.md
+++ b/docs/user-guide/5-threshold-selection.md
@@ -119,7 +119,7 @@ The `plot_parameter_stability` function uses the following parameters:
   to decluster exceedances by locating clusters where all exceedances are separated
   by distances no more than `r` and then locating maximum or minimum
   (depends on `extremes_type`) values within each cluster.
-  By default `#!python r="24H"` (24 hours).
+  By default `#!python r="24h"` (24 hours).
 - **extremes_type** - extreme value type:
   `#!python "high"` for above threshold (default)
   and `#!python "low"` for below threshold.
@@ -172,7 +172,7 @@ The `plot_return_value_stability` function uses the following parameters:
   to decluster exceedances by locating clusters where all exceedances are separated
   by distances no more than `r` and then locating maximum or minimum
   (depends on `extremes_type`) values within each cluster.
-  By default `#!python r="24H"` (24 hours).
+  By default `#!python r="24h"` (24 hours).
 - **extremes_type** - extreme value type:
   `#!python "high"` for above threshold (default)
   and `#!python "low"` for below threshold.
@@ -239,7 +239,7 @@ The `plot_threshold_stability` function uses the following parameters:
   to decluster exceedances by locating clusters where all exceedances are separated
   by distances no more than `r` and then locating maximum or minimum
   (depends on `extremes_type`) values within each cluster.
-  By default `#!python r="24H"` (24 hours).
+  By default `#!python r="24h"` (24 hours).
 - **extremes_type** - extreme value type:
   `#!python "high"` for above threshold (default)
   and `#!python "low"` for below threshold.

--- a/src/pyextremes/eva.py
+++ b/src/pyextremes/eva.py
@@ -446,7 +446,7 @@ class EVA:
         extremes_type: typing.Literal["high", "low"] = "high",
         *,
         threshold: float,
-        r: typing.Union[pd.Timedelta, typing.Any] = "24H",
+        r: typing.Union[pd.Timedelta, typing.Any] = "24h",
     ) -> None:
         ...
 
@@ -522,7 +522,7 @@ class EVA:
             )
         else:
             self.__extremes_kwargs["threshold"] = kwargs.get("threshold")
-            self.__extremes_kwargs["r"] = pd.to_timedelta(kwargs.get("r", "24H"))
+            self.__extremes_kwargs["r"] = pd.to_timedelta(kwargs.get("r", "24h"))
         logger.info("successfully collected extreme value properties")
 
         logger.debug("creating extremes transformer")
@@ -556,7 +556,7 @@ class EVA:
         extremes_type: typing.Literal["high", "low"] = "high",
         *,
         threshold: float,
-        r: typing.Union[pd.Timedelta, typing.Any] = "24H",
+        r: typing.Union[pd.Timedelta, typing.Any] = "24h",
     ) -> None:
         ...
 
@@ -699,7 +699,7 @@ class EVA:
                 raise ValueError("invalid `threshold` value")
 
             # Get `r`
-            extremes_kwargs["r"] = pd.to_timedelta(kwargs.pop("r", "24H"))
+            extremes_kwargs["r"] = pd.to_timedelta(kwargs.pop("r", "24h"))
             if extremes_kwargs["r"] <= pd.to_timedelta("0D"):
                 raise ValueError(
                     "`r` must be a positive timedelta, not %s" % extremes_kwargs["r"]
@@ -746,7 +746,7 @@ class EVA:
         extremes_type: typing.Literal["high", "low"] = "high",
         *,
         threshold: float,
-        r: typing.Union[pd.Timedelta, typing.Any] = "24H",
+        r: typing.Union[pd.Timedelta, typing.Any] = "24h",
     ) -> None:
         ...
 

--- a/src/pyextremes/extremes/extremes.py
+++ b/src/pyextremes/extremes/extremes.py
@@ -26,7 +26,7 @@ def get_extremes(
     extremes_type: Literal["high", "low"] = "high",
     *,
     threshold: float,
-    r: Union[pd.Timedelta, Any] = "24H",
+    r: Union[pd.Timedelta, Any] = "24h",
 ) -> pd.Series:
     ...
 

--- a/src/pyextremes/extremes/peaks_over_threshold.py
+++ b/src/pyextremes/extremes/peaks_over_threshold.py
@@ -51,7 +51,7 @@ def get_extremes_peaks_over_threshold(
     ts: pd.Series,
     extremes_type: Literal["high", "low"],
     threshold: float,
-    r: Union[pd.Timedelta, Any] = "24H",
+    r: Union[pd.Timedelta, Any] = "24h",
 ) -> pd.Series:
     """
     Get extreme events from time series using the Peaks Over Threshold method.

--- a/src/pyextremes/tuning/threshold_selection.py
+++ b/src/pyextremes/tuning/threshold_selection.py
@@ -251,7 +251,7 @@ def _calculate_modified_parameters(
 def plot_parameter_stability(
     ts: pd.Series,
     thresholds=None,
-    r: typing.Union[str, pd.Timedelta] = "24H",
+    r: typing.Union[str, pd.Timedelta] = "24h",
     extremes_type: str = "high",
     alpha: typing.Optional[float] = None,
     n_samples: int = 100,
@@ -518,7 +518,7 @@ def plot_return_value_stability(
     return_period: float,
     return_period_size: typing.Union[str, pd.Timedelta] = "365.2425D",
     thresholds=None,
-    r: typing.Union[str, pd.Timedelta] = "24H",
+    r: typing.Union[str, pd.Timedelta] = "24h",
     extremes_type: str = "high",
     distributions: typing.Optional[
         typing.List[typing.Union[str, scipy.stats.rv_continuous]]
@@ -728,7 +728,7 @@ def plot_return_value_stability(
 def plot_aic_scores(
     ts: pd.Series,
     thresholds=None,
-    r: typing.Union[str, pd.Timedelta] = "24H",
+    r: typing.Union[str, pd.Timedelta] = "24h",
     extremes_type: str = "high",
     distributions: typing.Optional[
         typing.List[typing.Union[str, scipy.stats.rv_continuous]]
@@ -853,7 +853,7 @@ def plot_threshold_stability(
     return_period: float,
     return_period_size: typing.Union[str, pd.Timedelta] = "365.2425D",
     thresholds=None,
-    r: typing.Union[str, pd.Timedelta] = "24H",
+    r: typing.Union[str, pd.Timedelta] = "24h",
     extremes_type: str = "high",
     distributions: typing.Optional[
         typing.List[typing.Union[str, scipy.stats.rv_continuous]]

--- a/tests/_shared_data/generator.py
+++ b/tests/_shared_data/generator.py
@@ -26,9 +26,9 @@ def main() -> None:
                 kwargs = {"block_size": "365.2425D", "errors": "ignore"}
             else:
                 if extremes_type == "high":
-                    kwargs = {"threshold": 1.35, "r": "24H"}
+                    kwargs = {"threshold": 1.35, "r": "24h"}
                 else:
-                    kwargs = {"threshold": -1.55, "r": "24H"}
+                    kwargs = {"threshold": -1.55, "r": "24h"}
             extremes = get_extremes(
                 ts=data, method=method, extremes_type=extremes_type, **kwargs
             )

--- a/tests/extremes/test_peaks_over_threshold.py
+++ b/tests/extremes/test_peaks_over_threshold.py
@@ -13,7 +13,7 @@ def test_invalid_arguments(battery_wl):
             method="POT",
             extremes_type="BAD EXTREMES_TYPE VALUE",
             threshold=2,
-            r="24H",
+            r="24h",
         )
 
     # Test wrong r type
@@ -30,7 +30,7 @@ def test_extreme_value_extraction(battery_wl, extremes_type, threshold):
         method="POT",
         extremes_type=extremes_type,
         threshold=threshold,
-        r="24H",
+        r="24h",
     )
     if extremes_type == "high":
         assert np.isclose(extremes.max(), battery_wl.max())
@@ -38,11 +38,11 @@ def test_extreme_value_extraction(battery_wl, extremes_type, threshold):
     elif extremes_type == "low":
         assert np.isclose(extremes.min(), battery_wl.min())
         assert len(extremes) == 104
-    assert np.all(np.diff(extremes.index) > pd.to_timedelta("24H").to_numpy())
+    assert np.all(np.diff(extremes.index) > pd.to_timedelta("24h").to_numpy())
 
 
 def test_single_cluster():
-    index = pd.date_range(start="2021/01/01", end="2021/01/02", freq="1H")
+    index = pd.date_range(start="2021/01/01", end="2021/01/02", freq="1h")
     data = pd.Series(data=np.random.random(size=len(index)), index=index)
 
     # Tesh high extremes
@@ -51,7 +51,7 @@ def test_single_cluster():
         method="POT",
         extremes_type="high",
         threshold=data.min() - 1,
-        r="24H",
+        r="24h",
     )
     assert len(extremes) == 1
     assert np.isclose(extremes.values[0], data.max())
@@ -62,7 +62,7 @@ def test_single_cluster():
         method="POT",
         extremes_type="low",
         threshold=data.max() + 1,
-        r="24H",
+        r="24h",
     )
     assert len(extremes) == 1
     assert np.isclose(extremes.values[0], data.min())
@@ -86,7 +86,7 @@ def test_threshold_producing_empty_series(battery_wl: pd.Series, extremes_type: 
             threshold=battery_wl.max() + 1
             if extremes_type == "high"
             else battery_wl.min() - 1,
-            r="24H",
+            r="24h",
         )
     assert isinstance(extremes, pd.Series)
     assert len(extremes) == 0

--- a/tests/integration/test_eva.py
+++ b/tests/integration/test_eva.py
@@ -31,7 +31,7 @@ def eva_model_pot(battery_wl_preprocessed) -> EVA:
         method="POT",
         extremes_type="high",
         threshold=1.35,
-        r="24H",
+        r="24h",
     )
     return eva_model
 
@@ -69,7 +69,7 @@ def eva_model_pot_mle(battery_wl_preprocessed) -> EVA:
         method="POT",
         extremes_type="high",
         threshold=1.35,
-        r="24H",
+        r="24h",
     )
     eva_model.fit_model("MLE")
     return eva_model
@@ -163,7 +163,7 @@ class TestEVA:
                 "method": "POT",
                 "extremes_type": "high",
                 "threshold": 1.35,
-                "r": "24H",
+                "r": "24h",
             },
             {
                 "method": "POT",
@@ -188,7 +188,7 @@ class TestEVA:
         else:
             assert len(eva_model.extremes_kwargs) == 2
             assert eva_model.extremes_kwargs["threshold"] == 1.35
-            assert eva_model.extremes_kwargs["r"] == pd.to_timedelta("24H")
+            assert eva_model.extremes_kwargs["r"] == pd.to_timedelta("24h")
         with pytest.raises(AttributeError, match=r"model must first"):
             eva_model.model
 
@@ -384,7 +384,7 @@ class TestEVA:
             extremes_type="high",
         )
         assert np.isclose(eva_model.extremes_kwargs["threshold"], 0, rtol=0, atol=1e-6)
-        assert eva_model.extremes_kwargs["r"] == pd.to_timedelta("24H")
+        assert eva_model.extremes_kwargs["r"] == pd.to_timedelta("24h")
         eva_model = EVA.from_extremes(
             extremes=pd.Series(
                 data=np.arange(100),
@@ -395,7 +395,7 @@ class TestEVA:
             extremes_type="low",
         )
         assert np.isclose(eva_model.extremes_kwargs["threshold"], 99, rtol=0, atol=1e-6)
-        assert eva_model.extremes_kwargs["r"] == pd.to_timedelta("24H")
+        assert eva_model.extremes_kwargs["r"] == pd.to_timedelta("24h")
 
     @pytest.mark.parametrize(
         "extremes_params",

--- a/tests/models/test_distribution.py
+++ b/tests/models/test_distribution.py
@@ -59,7 +59,7 @@ class TestDistribution:
             scipy_distribution = getattr(scipy.stats, distribution_name)
         distribution = Distribution(
             extremes=pd.Series(
-                index=pd.date_range(start="2000-01-01", periods=100, freq="1H"),
+                index=pd.date_range(start="2000-01-01", periods=100, freq="1h"),
                 data=scipy_distribution.rvs(*scipy_parameters, size=100),
             ),
             distribution=distribution_input,

--- a/tests/models/test_model_emcee.py
+++ b/tests/models/test_model_emcee.py
@@ -10,7 +10,7 @@ from pyextremes.models import Emcee, get_model
 def extremes() -> pd.Series:
     np.random.seed(0)
     return pd.Series(
-        index=pd.date_range(start="2000-01-01", periods=1000, freq="1H"),
+        index=pd.date_range(start="2000-01-01", periods=1000, freq="1h"),
         data=scipy.stats.genextreme.rvs(c=0, loc=10, scale=2, size=1000),
     )
 
@@ -163,7 +163,7 @@ class TestEmcee:
 
         np.random.seed(0)
         extremes = pd.Series(
-            index=pd.date_range(start="2000-01-01", periods=100, freq="1H"),
+            index=pd.date_range(start="2000-01-01", periods=100, freq="1h"),
             data=scipy_distribution.rvs(*scipy_parameters, size=100),
         )
         model = get_model(

--- a/tests/models/test_model_mle.py
+++ b/tests/models/test_model_mle.py
@@ -12,7 +12,7 @@ from pyextremes.models import MLE, get_model
 def extremes() -> pd.Series:
     np.random.seed(0)
     return pd.Series(
-        index=pd.date_range(start="2000-01-01", periods=1000, freq="1H"),
+        index=pd.date_range(start="2000-01-01", periods=1000, freq="1h"),
         data=scipy.stats.genextreme.rvs(c=0, loc=10, scale=2, size=1000),
     )
 
@@ -214,7 +214,7 @@ class TestMLE:
 
         np.random.seed(0)
         extremes = pd.Series(
-            index=pd.date_range(start="2000-01-01", periods=100, freq="1H"),
+            index=pd.date_range(start="2000-01-01", periods=100, freq="1h"),
             data=scipy_distribution.rvs(*scipy_parameters, size=100),
         )
         model = get_model(


### PR DESCRIPTION
The pandas offset alias for hour is `h`, and the capitalised version `H` is deprecated.

> FutureWarning: 'H' is deprecated and will be removed in a future version. Please use 'h' instead of 'H'.

This PR updates all uses of `"__H"` to `"__h"`.
